### PR TITLE
Fixed bug that breaks when trying to share profile

### DIFF
--- a/app/controllers/public_profiles_controller.rb
+++ b/app/controllers/public_profiles_controller.rb
@@ -9,7 +9,8 @@ class PublicProfilesController < ApplicationController
   private
 
   def developer
-    Developer.find_by_hashid!(params[:developer_id])
+    developer_instance = Developer.find_by_hashid!(params[:developer_id])
     Analytics::Event.developer_public_profile_viewed(current_user, cookies, params[:developer_id])
+    developer_instance
   end
 end


### PR DESCRIPTION
<!-- Description of pull request linking to any relevant issues. -->

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] My code contains tests covering the code I modified
- [ ] I linted and tested the project with `bin/check`
- [ ] I added significant changes and product updates to the [changelog](CHANGELOG.md)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->

By assigning the found Developer instance to a variable (developer_instance) and explicitly returning it at the end of the method, you ensure that the authorize @developer, :share_profile? call in your new action is performed on a Developer instance, which should resolve the issue with finding the appropriate policy class.







