### PR TITLE
fix(devcontainer): Add root user permissions for docker image build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,7 @@
 FROM --platform=linux/amd64 ghcr.io/rails/devcontainer/images/ruby:3.2.2
 
+USER root
+
 RUN set -xe \
     && apt update && apt -y upgrade
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,6 @@
 FROM --platform=linux/amd64 ghcr.io/rails/devcontainer/images/ruby:3.2.2
 
+# Switch to root to install dependencies
 USER root
 
 RUN set -xe \
@@ -34,9 +35,10 @@ RUN set -xe \
     && apt update \
     && apt -y install --no-install-recommends google-chrome-stable
 
-# Create a User
+# Create a non-root user
 RUN set -xe \
-    && echo 'ALL ALL = (ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers
+    && useradd -m -s /bin/bash appuser \
+    && echo 'appuser ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Install NodeJS
 RUN set -xe \ 
@@ -50,3 +52,6 @@ RUN set -xe \
 # Install Application Dependencies
 RUN set -xe \ 
     && apt -y install --no-install-recommends libpq-dev imagemagick libvips-dev libvips-tools libvips42 ruby-chromedriver-helper ruby-foreman
+
+# Switch to non-root user
+USER appuser


### PR DESCRIPTION
<!-- Description of pull request linking to any relevant issues. -->
## Description
When I cloned the repo and tried to build the `devcontainer` I experienced an error failing the build. The error described pointed to a permissions issue while installing the container dependancies. Setting the USER to root in the docker image build fixes this issue.

Added a non-root user to switch to after dependancies are installed to reduce privileges in the running container for enhanced security.

## Pull request checklist

<!-- Before you submit a pull request for review, please make sure... -->

- [ ] ~My code contains tests covering the code I modified~ (Not applicable)
- [x] I linted and tested the project with `bin/check`
- [ ] ~I added significant changes and product updates to the [changelog](CHANGELOG.md)~ (Not applicable)

<!-- If this PR is not ready for review, please make sure to submit it as a draft. -->
