### PR TITLE
feat: location filter by city instead of country

### DIFF
--- a/app/components/developers/query_component.html.erb
+++ b/app/components/developers/query_component.html.erb
@@ -103,13 +103,13 @@
     <div data-controller="toggle accessibility" data-toggle-visibility-class="hidden">
       <div class="border-t border-gray-200 py-6">
         <h3 class="-mx-2 -my-3 flow-root">
-          <%= render CollapseControlComponent.new(t(".country.title"), collapsed: collapse_location?) %>
+          <%= render CollapseControlComponent.new(t(".city.title"), collapsed: collapse_location?) %>
         </h3>
         <%= tag.div id: "location-accordion", "data-toggle-target": "element", class: [hidden: collapse_location?] do %>
           <div class="space-y-4 pt-6">
-            <%= form.collection_check_boxes(:countries, top_countries, :first, :last, {include_hidden: false}) do |b| %>
+            <%= form.collection_check_boxes(:cities, top_cities, :first, :last, {include_hidden: false}) do |b| %>
               <div class="flex items-center">
-                <%= b.check_box checked: country_selected?(b.object), class: "h-4 w-4 border-gray-300 rounded text-blue-950 focus:ring-blue-500" %>
+                <%= b.check_box checked: city_selected?(b.object), class: "h-4 w-4 border-gray-300 rounded text-blue-950 focus:ring-blue-500" %>
                 <%= b.label class: "ml-3 text-blue-950 text-sm" %>
               </div>
             <% end %>
@@ -117,13 +117,13 @@
           <div data-controller="toggle accessibility" data-toggle-visibility-class="hidden">
             <div class="pt-6">
               <h5 class="-mx-2 -my-3 flow-root">
-                <%= render CollapseControlComponent.new(t(".all_countries.title"), collapsed: collapse_all_locations?, subcomponent: true) %>
+                <%= render CollapseControlComponent.new(t(".all_cities.title"), collapsed: collapse_all_locations?, subcomponent: true) %>
               </h5>
               <%= tag.div id: "all-locations-accordion", "data-toggle-target": "element", class: [hidden: collapse_all_locations?] do %>
                 <div class="space-y-4 pt-6">
-                  <%= form.collection_check_boxes(:countries, countries, :first, :last, {include_hidden: false}) do |b| %>
+                  <%= form.collection_check_boxes(:cities, cities, :first, :last, {include_hidden: false}) do |b| %>
                     <div class="flex items-center">
-                      <%= b.check_box checked: country_selected?(b.object), class: "h-4 w-4 border-gray-300 rounded text-blue-950 focus:ring-blue-500" %>
+                      <%= b.check_box checked: city_selected?(b.object), class: "h-4 w-4 border-gray-300 rounded text-blue-950 focus:ring-blue-500" %>
                       <%= b.label class: "ml-3 text-blue-950 text-sm" %>
                     </div>
                   <% end %>

--- a/app/components/developers/query_component.rb
+++ b/app/components/developers/query_component.rb
@@ -10,6 +10,18 @@ module Developers
       @form_id = form_id
     end
 
+    def city_selected?(city_pair)
+      query.cities.include?(city_pair.first)
+    end
+
+    def top_cities
+      Location.top_cities.map { |k| [k, k] }
+    end
+
+    def cities
+      Location.not_top_cities.map { |k| [k, k] }
+    end
+
     def country_selected?(country_pair)
       query.countries.include?(country_pair.first)
     end
@@ -83,12 +95,12 @@ module Developers
     end
 
     def collapse_location?
-      query.countries.empty?
+      query.cities.empty?
     end
 
     def collapse_all_locations?
       @collapse_all_locations ||=
-        (Location.not_top_countries & query.countries).none?
+        (Location.not_top_cities & query.cities).none?
     end
 
     def collapse_timezone?

--- a/app/components/developers/query_mobile_component.html.erb
+++ b/app/components/developers/query_mobile_component.html.erb
@@ -98,13 +98,13 @@
         </div>
         <div data-controller="toggle" data-toggle-visibility-class="hidden" class="border-t border-gray-200 px-4 py-6">
           <h3 class="-mx-2 -my-3 flow-root">
-            <%= render CollapseControlComponent.new(t("developers.query_component.country.title"), collapsed: true) %>
+            <%= render CollapseControlComponent.new(t("developers.query_component.city.title"), collapsed: true) %>
           </h3>
-          <div id="top-countries-filter-section" data-toggle-target="element" class="hidden pt-6">
+          <div id="top-cities-filter-section" data-toggle-target="element" class="hidden pt-6">
             <div class="space-y-6">
-              <%= form.collection_check_boxes(:countries, top_countries, :first, :last, {include_hidden: false}) do |b| %>
+              <%= form.collection_check_boxes(:cities, top_cities, :first, :last, {include_hidden: false}) do |b| %>
                 <div class="flex items-center">
-                  <%= b.check_box class: "h-4 w-4 border-gray-300 rounded text-blue-950 focus:ring-blue-500", checked: country_selected?(b.object) %>
+                  <%= b.check_box class: "h-4 w-4 border-gray-300 rounded text-blue-950 focus:ring-blue-500", checked: city_selected?(b.object) %>
                   <%= b.label class: "ml-3 pr-6 text-sm font-medium text-blue-900 whitespace-nowrap" %>
                 </div>
               <% end %>
@@ -112,14 +112,14 @@
             <div data-controller="toggle" data-toggle-visibility-class="hidden">
               <div class="pt-6">
                 <h5 class="-mx-2 -my-3 flow-root">
-                  <%= render CollapseControlComponent.new(t("developers.query_component.all_countries.title"), collapsed: true, subcomponent: true) %>
+                  <%= render CollapseControlComponent.new(t("developers.query_component.all_cities.title"), collapsed: true, subcomponent: true) %>
                 </h5>
               </div>
-              <div id="all-countries-filter-section" data-toggle-target="element" class="hidden">
+              <div id="all-cities-filter-section" data-toggle-target="element" class="hidden">
                 <div class="space-y-4 pt-6">
-                  <%= form.collection_check_boxes(:countries, countries, :first, :last, {include_hidden: false}) do |b| %>
+                  <%= form.collection_check_boxes(:cities, cities, :first, :last, {include_hidden: false}) do |b| %>
                     <div class="flex items-center">
-                      <%= b.check_box class: "h-4 w-4 border-gray-300 rounded text-blue-950 focus:ring-blue-500", checked: country_selected?(b.object) %>
+                      <%= b.check_box class: "h-4 w-4 border-gray-300 rounded text-blue-950 focus:ring-blue-500", checked: city_selected?(b.object) %>
                       <%= b.label class: "ml-3 pr-6 text-sm font-medium text-blue-900 whitespace-nowrap" %>
                     </div>
                   <% end %>

--- a/app/controllers/developers_controller.rb
+++ b/app/controllers/developers_controller.rb
@@ -7,6 +7,7 @@ class DevelopersController < ApplicationController
     @developers_count = SignificantFigure.new(Developer.actively_looking_or_open.count).rounded
     @query = DeveloperQuery.new(permitted_attributes([:developers, :query]).merge(user: current_user))
     @meta = Developers::Meta.new(query: @query, count: @developers_count)
+
     Analytics::SearchQuery.create!(permitted_attributes([:developers, :query]))
 
     if @query.empty_search?

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -72,6 +72,10 @@ class Developer < ApplicationRecord
     joins(:location).where(locations: {country: countries})
   end
 
+  scope :filter_by_cities, ->(cities) do
+    joins(:location).where(locations: {city: cities})
+  end
+
   scope :actively_looking_or_open, -> { where(search_status: [:actively_looking, :open, nil]) }
   scope :featured, -> { where("featured_at >= ?", FEATURE_LENGTH.ago).order(featured_at: :desc) }
   scope :newest_first, -> { order(created_at: :desc) }

--- a/app/models/developers/meta.rb
+++ b/app/models/developers/meta.rb
@@ -54,6 +54,12 @@ module Developers
         !query.role_types.include?(:full_time_employment)
     end
 
+    def city
+      if query.cities.one?
+        query.cities.first
+      end
+    end
+
     def country
       if query.countries.one?
         query.countries.first

--- a/app/models/developers/query_path.rb
+++ b/app/models/developers/query_path.rb
@@ -26,6 +26,10 @@ module Developers
 
     private
 
+    def top_cities
+      @top_cities ||= Location.top_cities
+    end
+
     def top_countries
       @top_countries ||= Location.top_countries
     end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -18,6 +18,23 @@ class Location < ApplicationRecord
       .pluck(:country)
   end
 
+  scope :top_cities, ->(limit = ENV.fetch("TOP_CITIES", 10)) do
+    group(:city)
+      .where.not(city: nil)
+      .order("count_all DESC")
+      .limit(limit)
+      .count
+      .keys
+  end
+
+  scope :not_top_cities, ->(limit = ENV.fetch("TOP_CITIES", 10)) do
+    where.not(city: top_cities(limit))
+      .select(:city)
+      .distinct
+      .order(:city)
+      .pluck(:city)
+  end
+
   validates :time_zone, presence: true
   validates :utc_offset, presence: true
   validate :valid_coordinates

--- a/app/policies/developers/query_policy.rb
+++ b/app/policies/developers/query_policy.rb
@@ -19,7 +19,8 @@ module Developers
         role_types: [],
         badges: [],
         utc_offsets: [],
-        countries: []
+        countries: [],
+        cities: []
       ]
     end
 

--- a/app/queries/developer_query.rb
+++ b/app/queries/developer_query.rb
@@ -11,6 +11,7 @@ class DeveloperQuery
     @sort = options.delete(:sort)
     @specialty_ids = options.delete(:specialty_ids)
     @countries = options.delete(:countries)
+    @cities = options.delete(:cities)
     @utc_offsets = options.delete(:utc_offsets)
     @role_types = options.delete(:role_types)
     @role_levels = options.delete(:role_levels)
@@ -21,7 +22,7 @@ class DeveloperQuery
   end
 
   def filters
-    @filters = {sort:, utc_offsets:, role_types:, role_levels:, include_not_interested:, search_query:, countries:,
+    @filters = {sort:, utc_offsets:, role_types:, role_levels:, include_not_interested:, search_query:, countries:, cities:,
                 badges:}
   end
 
@@ -43,6 +44,10 @@ class DeveloperQuery
 
   def sort
     (@sort.to_s.downcase.to_sym == :recommended) ? :recommended : :newest
+  end
+
+  def cities
+    @cities.to_a.reject(&:blank?)
   end
 
   def countries
@@ -79,6 +84,7 @@ class DeveloperQuery
       sort: @sort,
       specialty_ids: @specialty_ids,
       countries: @countries,
+      cities: @cities,
       search_query:,
       utc_offsets: @utc_offsets,
       role_types: @role_types,
@@ -98,6 +104,7 @@ class DeveloperQuery
       role_levels.empty? &&
       search_query.blank? &&
       countries.blank? &&
+      cities.blank? &&
       badges.blank? &&
       specialty_ids.empty? &&
       !include_not_interested
@@ -109,6 +116,7 @@ class DeveloperQuery
     @_records = Developer.includes(:role_type, :specialties).with_attached_avatar.visible
     sort_records
     country_filter_records
+    city_filter_records
     utc_offset_filter_records
     role_type_filter_records
     role_level_filter_records
@@ -151,6 +159,10 @@ class DeveloperQuery
     else
       @_records.merge!(Developer.newest_first)
     end
+  end
+
+  def city_filter_records
+    @_records.merge!(Developer.filter_by_cities(cities)) if cities.any?
   end
 
   def country_filter_records

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -508,15 +508,15 @@ en:
       add_profile: Add my profile
       edit_profile: Update my profile
     query_component:
-      all_countries:
-        title: All locations
+      all_cities:
+        title: All cities
       apply: Apply
       badge:
         title: Badges
+      city:
+        title: City
       clear: Clear
       close_menu: Close menu
-      country:
-        title: Location
       filters: Filters
       include_not_interested: Include developers not currently interested
       paywalled_search:

--- a/db/migrate/20250718163920_add_cities_to_analytics_search_queries.rb
+++ b/db/migrate/20250718163920_add_cities_to_analytics_search_queries.rb
@@ -1,0 +1,5 @@
+class AddCitiesToAnalyticsSearchQueries < ActiveRecord::Migration[7.0]
+  def change
+    add_column :analytics_search_queries, :cities, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_18_220241) do
+ActiveRecord::Schema[7.0].define(version: 2025_07_18_163920) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,6 +73,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_18_220241) do
     t.integer "page"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "cities"
   end
 
   create_table "businesses", force: :cascade do |t|

--- a/test/components/developers/query_component_test.rb
+++ b/test/components/developers/query_component_test.rb
@@ -9,29 +9,29 @@ module Developers
       @user = users(:empty)
     end
 
-    test "renders top countries for developers" do
+    test "renders top cities for developers" do
       query = DeveloperQuery.new({})
-      Location.stub :top_countries, ["China", "United States"] do
+      Location.stub :top_cities, ["New York", "Portland"] do
         render_inline QueryComponent.new(query:, user: @user, form_id: nil)
       end
 
-      assert_selector build_input("countries[]", type: "checkbox", value: "United States")
-      assert_selector build_input("countries[]", type: "checkbox", value: "China")
+      assert_selector build_input("cities[]", type: "checkbox", value: "New York")
+      assert_selector build_input("cities[]", type: "checkbox", value: "Portland")
     end
 
-    test "renders unique countries for developers" do
+    test "renders unique cities for developers" do
       query = DeveloperQuery.new({})
       render_inline QueryComponent.new(query:, user: @user, form_id: nil)
 
-      assert_selector build_input("countries[]", type: "checkbox", value: "United States")
-      assert_selector "label[for=countries_united_states]", text: "United States"
+      assert_selector build_input("cities[]", type: "checkbox", value: "Tampa")
+      assert_selector "label[for=cities_tampa]", text: "Tampa"
     end
 
-    test "checks selected countries" do
-      query = DeveloperQuery.new(countries: ["United States"])
+    test "checks selected cities" do
+      query = DeveloperQuery.new(cities: ["Tampa"])
       render_inline QueryComponent.new(query:, user: @user, form_id: nil)
 
-      assert_selector build_input("countries[]", type: "checkbox", value: "United States", checked: true)
+      assert_selector build_input("cities[]", type: "checkbox", value: "Tampa", checked: true)
     end
 
     test "renders unique UTC offset pairs for developers" do
@@ -106,20 +106,20 @@ module Developers
     end
 
     test "collapse location accordion when location is not being queried" do
-      create_developer(location_attributes: {country: "Australia"})
+      create_developer(location_attributes: {city: "Portland"})
 
-      Location.stub :top_countries, ["United States"] do
+      Location.stub :top_cities, ["New York"] do
         query = DeveloperQuery.new
         render_inline QueryComponent.new(query:, user: @user, form_id: nil)
         assert_selector("#location-accordion.hidden")
         assert_selector("#all-locations-accordion.hidden")
 
-        query = DeveloperQuery.new(countries: ["United States"])
+        query = DeveloperQuery.new(cities: ["New York"])
         render_inline QueryComponent.new(query:, user: @user, form_id: nil)
         assert_selector("#location-accordion:not(.hidden)")
         assert_selector("#all-locations-accordion.hidden")
 
-        query = DeveloperQuery.new(countries: ["Australia"])
+        query = DeveloperQuery.new(cities: ["Portland"])
         render_inline QueryComponent.new(query:, user: @user, form_id: nil)
         assert_selector("#location-accordion:not(.hidden)")
         assert_selector("#all-locations-accordion:not(.hidden)")

--- a/test/fixtures/locations.yml
+++ b/test/fixtures/locations.yml
@@ -1,5 +1,6 @@
 one:
   developer: one
+  city: Tampa
   country: United States
   time_zone: Eastern Time (US & Canada)
   utc_offset: -18_000

--- a/test/integration/developers_test.rb
+++ b/test/integration/developers_test.rb
@@ -65,7 +65,9 @@ class DevelopersTest < ActionDispatch::IntegrationTest
 
     get developers_path(countries: [country])
 
-    assert_select "input[checked][type=checkbox][value='#{country}'][name='countries[]']"
+    # Select input has been removed in favor of filtering by city
+    # assert_select "input[checked][type=checkbox][value='#{country}'][name='countries[]']"
+
     assert_text "Hire developers in Tampa Bay in #{country}"
   end
 

--- a/test/models/developers/query_path_test.rb
+++ b/test/models/developers/query_path_test.rb
@@ -17,7 +17,7 @@ class Developers::QueryPathTest < ActiveSupport::TestCase
   end
 
   def location_combinations
-    Location.top_countries.count
+    Location.top_cities.count
   end
 
   def role_level_by_location_combinations

--- a/test/queries/developer_query_test.rb
+++ b/test/queries/developer_query_test.rb
@@ -68,13 +68,13 @@ class DeveloperQueryTest < ActiveSupport::TestCase
     assert records.find_index(newest) < records.find_index(oldest)
   end
 
-  test "filtering by countries" do
+  test "filtering by cities" do
     united_states = create_developer
-    singapore = create_developer(location_attributes: {country: "Singapore"})
+    tampa = create_developer(location_attributes: {city: "Tampa"})
 
-    records = DeveloperQuery.new(countries: ["Singapore"]).records
+    records = DeveloperQuery.new(cities: ["Tampa"]).records
 
-    assert_includes records, singapore
+    assert_includes records, tampa
     refute_includes records, united_states
   end
 
@@ -206,6 +206,7 @@ class DeveloperQueryTest < ActiveSupport::TestCase
       include_not_interested: true,
       search_query: "rails engineer",
       countries: ["United States"],
+      cities: [],
       badges: [:recently_added]
     }
     assert_equal DeveloperQuery.new(filters.dup).filters, filters


### PR DESCRIPTION
This PR changes the Location filtering logic and UI to filter by city rather than country (which makes sense given TDT's local focus).